### PR TITLE
Issue #76: Save Ussd response string to CDRs

### DIFF
--- a/core/domain/src/main/java/org/mobicents/ussdgateway/UssdPropertiesManagement.java
+++ b/core/domain/src/main/java/org/mobicents/ussdgateway/UssdPropertiesManagement.java
@@ -102,6 +102,8 @@ public class UssdPropertiesManagement implements UssdPropertiesManagementMBean {
     // max count of TCAP Dialogs that are possible at the same time
     private int maxActivityCount = 5000;
 
+	private boolean cdrNavigationSave;
+
 	private UssdPropertiesManagement(String name) {
 		this.name = name;
 		binding.setClassAttribute(CLASS_ATTRIBUTE);
@@ -275,6 +277,15 @@ public class UssdPropertiesManagement implements UssdPropertiesManagementMBean {
 
     public void setCdrLoggingTo(CdrLoggedType cdrLoggingTo) {
         this.cdrLoggingTo = cdrLoggingTo;
+        this.store();
+    }
+
+    public boolean getCdrNavigationSave() {
+        return cdrNavigationSave;
+    }
+
+    public void getCdrNavigationSave(boolean cdrNavigationSave) {
+        this.cdrNavigationSave = cdrNavigationSave;
         this.store();
     }
 

--- a/core/slee/sbbs/src/main/java/org/mobicents/ussdgateway/slee/cdr/USSDCDRState.java
+++ b/core/slee/sbbs/src/main/java/org/mobicents/ussdgateway/slee/cdr/USSDCDRState.java
@@ -61,6 +61,8 @@ public class USSDCDRState implements Serializable {
 
 	private USSDType ussdType = USSDType.PULL;
 
+	private String ussdString;
+
 	/**
 	 * @return the destReference
 	 */
@@ -291,6 +293,16 @@ public class USSDCDRState implements Serializable {
 		this.ussdType = ussdType;
 	}
 
+	public String getUssdString() {
+		// TODO Auto-generated method stub
+		return this.ussdString;
+	}
+
+	public void setUssdString(String ussdString) {
+		// TODO Auto-generated method stub
+		this.ussdString = ussdString;
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * 
@@ -415,5 +427,6 @@ public class USSDCDRState implements Serializable {
 				+ ", remoteDialogId=" + remoteDialogId + ", id=" + id + ", recordStatus=" + recordStatus
 				+ ", ussdType=" + ussdType + " ]@" + super.hashCode();
 	}
+
 
 }


### PR DESCRIPTION
@vetss Sergey, this is an incomplete proposal for saving Ussd response strings to the CDR. 
* Add UssdString property with getter/setter to USSDCDRState
* Add new configuration flag to enable disable saving of response strings. Add new cdrNavigationSave property with new getter/setter to UssdPropertiesManagement

Is this approach correct? 
There are obvious things missing here of course, reading and saving the new config (additionally the duration changes got added by mistake)