### PR TITLE
Issue #76: Add null check for jdbc ussdString

### DIFF
--- a/core/slee/sbbs/src/main/java/org/mobicents/ussdgateway/slee/cdr/jdbc/task/CDRCreateTask.java
+++ b/core/slee/sbbs/src/main/java/org/mobicents/ussdgateway/slee/cdr/jdbc/task/CDRCreateTask.java
@@ -283,7 +283,7 @@ public class CDRCreateTask extends CDRTaskBase {
 
             //_COLUMN_USSD_STRING
             String ussdString = state.getUssdString();
-            if(!ussdString.isEmpty()){
+            if(ussdString != null && !ussdString.isEmpty()){
                 preparedStatement.setString(28, ussdString);
             }else{
                 preparedStatement.setNull(28, Types.VARCHAR);


### PR DESCRIPTION
@vetss After further testing, ive identified bug i left in the `jdbc.task.CDRCreateTask` which just needs a nullcheck